### PR TITLE
Added explicit import of javax.xml.bind

### DIFF
--- a/bundles/edu.kit.ipd.sdq.eventsim.instrumentation.description/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.eventsim.instrumentation.description/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Export-Package: edu.kit.ipd.sdq.eventsim.instrumentation.description,
  edu.kit.ipd.sdq.eventsim.instrumentation.description.resource,
  edu.kit.ipd.sdq.eventsim.instrumentation.description.useraction,
  edu.kit.ipd.sdq.eventsim.instrumentation.xml
-Import-Package: org.palladiosimulator.pcm.seff
+Import-Package: javax.xml.bind,
+ org.palladiosimulator.pcm.seff

--- a/bundles/edu.kit.ipd.sdq.eventsim.instrumentation.specification/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.eventsim.instrumentation.specification/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Export-Package: edu.kit.ipd.sdq.eventsim.instrumentation.specification.editor,
  edu.kit.ipd.sdq.eventsim.instrumentation.specification.repo,
  edu.kit.ipd.sdq.eventsim.instrumentation.specification.restriction,
  edu.kit.ipd.sdq.eventsim.instrumentation.specification.util
+Import-Package: javax.xml.bind

--- a/bundles/edu.kit.ipd.sdq.eventsim.launch/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.eventsim.launch/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: edu.kit.ipd.sdq.eventsim.launch,
  edu.kit.ipd.sdq.eventsim.launch.runconfig,
  edu.kit.ipd.sdq.eventsim.launch.workflow.jobs
+Import-Package: javax.xml.bind

--- a/bundles/edu.kit.ipd.sdq.eventsim.resources/src/edu/kit/ipd/sdq/eventsim/resources/entities/SimActiveResource.java
+++ b/bundles/edu.kit.ipd.sdq.eventsim.resources/src/edu/kit/ipd/sdq/eventsim/resources/entities/SimActiveResource.java
@@ -1,6 +1,5 @@
 package edu.kit.ipd.sdq.eventsim.resources.entities;
 
-import org.omg.CORBA.Request;
 import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
 import org.palladiosimulator.pcm.resourcetype.ProcessingResourceType;


### PR DESCRIPTION
The bundles depend on the javax.xml.bind package that is not included in the SDK in Java 11 anymore. Therefore, I added an explicit dependency to the package in the bundle MANIFESTS.

@sdkrach You had the project in your working space. If you did not experience the issue, there might be a fault in my installation.